### PR TITLE
Use the sql state error code

### DIFF
--- a/src/framework/pdo/PreparedPDOStatement.php
+++ b/src/framework/pdo/PreparedPDOStatement.php
@@ -110,15 +110,15 @@ class PreparedPDOStatement implements PreparedStatement
             $time_msec = ($microtime_end - $microtime_begin) * 1000;
             $this->logger->logQuery($this->handle->queryString, $this->params, $time_msec);
         } else {
-            list($sql_state, $error_code, $error_message) = $this->handle->errorInfo();
+            list($sql_state_error_code, $driver_error_code, $error_message) = $this->handle->errorInfo();
 
-            $exception_type = $this->exception_mapper->getExceptionType($sql_state, $error_code, $error_message);
+            $exception_type = $this->exception_mapper->getExceptionType($sql_state_error_code, $driver_error_code, $error_message);
 
             throw new $exception_type(
                 $this->handle->queryString,
                 $this->params,
-                "{$sql_state}: {$error_message}",
-                $error_code
+                "{$driver_error_code}: {$error_message}",
+                $sql_state_error_code
             );
         }
     }


### PR DESCRIPTION
I'll did this to point out what the issue is about, you are welcome to disagree, or update.

But I need the sql state error code in my project, and the only way to get the code is from the string right now. I think the driver error code is for more "internal" use?

But at least, I am more intetessered in the datebase error codes (https://www.postgresql.org/docs/9.4/static/errcodes-appendix.html) when I call getCode() on the exception :-)